### PR TITLE
[Fix] Prevent getDb() from caching partially-initialized DB handle

### DIFF
--- a/packages/listing-processor/src/db.ts
+++ b/packages/listing-processor/src/db.ts
@@ -13,9 +13,15 @@ let _db: Database.Database | undefined;
 /** Get or create the shared SQLite connection. */
 export function getDb(): Database.Database {
   if (!_db) {
-    _db = new Database(DB_PATH, { timeout: 30_000 });
-    _db.pragma('journal_mode = WAL');
-    applySchema(_db);
+    const db = new Database(DB_PATH, { timeout: 30_000 });
+    try {
+      db.pragma('journal_mode = WAL');
+      applySchema(db);
+    } catch (err) {
+      db.close();
+      throw err;
+    }
+    _db = db;
   }
   return _db;
 }

--- a/packages/upload-api/src/db.ts
+++ b/packages/upload-api/src/db.ts
@@ -11,10 +11,16 @@ let _db: Database.Database | undefined;
 /** Get or create the shared SQLite connection. */
 export function getDb(): Database.Database {
   if (!_db) {
-    _db = new Database(DB_PATH, { timeout: 30_000 });
-    _db.pragma('journal_mode = WAL');
-    applySchema(_db);
-    applyUploadApiSchema(_db);
+    const db = new Database(DB_PATH, { timeout: 30_000 });
+    try {
+      db.pragma('journal_mode = WAL');
+      applySchema(db);
+      applyUploadApiSchema(db);
+    } catch (err) {
+      db.close();
+      throw err;
+    }
+    _db = db;
   }
   return _db;
 }


### PR DESCRIPTION
## Summary
- Fixes `getDb()` in both services to only assign the singleton `_db` after all initialization succeeds
- On failure, the database handle is properly closed and the error is re-thrown for a clean startup crash

## Issues Resolved
- Closes #31 — getDb() singleton leaves partially-initialized database handle on initDb() failure

## Changes
- **File:** `packages/listing-processor/src/db.ts` — Refactored getDb() to use local variable with try/catch guard
- **File:** `packages/upload-api/src/db.ts` — Same fix applied

## Verification
- [x] Build passes (`pnpm build`)
- [x] No unrelated changes
- [x] All resolved issues have `Closes #XX`

## Notes for Reviewer
The shared `lib/db` package (applySchema) was not affected — the bug was in the calling pattern, not the schema function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)