### PR TITLE
[Fix] Cap /products Odoo fetch at 2000 records

### DIFF
--- a/packages/listing-processor/src/index.ts
+++ b/packages/listing-processor/src/index.ts
@@ -304,10 +304,13 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
         return [] as Array<[string, string, unknown]>;
       };
 
+      const MAX_PRODUCTS = 2000;
       const filteredScanTotal = await odoo.searchCount('product.product', scanDomain(scanFilter));
+      const fetchLimit = Math.min(filteredScanTotal, MAX_PRODUCTS);
+      const resultsCapped = filteredScanTotal > MAX_PRODUCTS;
       const allProducts: OdooProduct[] = [];
       const batchSize = 500;
-      for (let offset = 0; offset < filteredScanTotal; offset += batchSize) {
+      for (let offset = 0; offset < fetchLimit; offset += batchSize) {
         const batch = await odoo.searchRead<OdooProduct>(
           'product.product', scanDomain(scanFilter),
           { fields: [...DEFAULT_PRODUCT_FIELDS] as any, limit: batchSize, offset },
@@ -377,6 +380,7 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
         perPage, perPageOptions: PER_PAGE_OPTIONS,
         listingFilter, listingFilterOptions, statusCounts,
         activeNav: 'products',
+        resultsCapped, cappedTotal: filteredScanTotal,
       });
     } catch (err) {
       flash(reply, 'error', `Odoo error: ${(err as Error).message}`);

--- a/packages/listing-processor/templates/products.eta
+++ b/packages/listing-processor/templates/products.eta
@@ -50,6 +50,12 @@
     <% } %>
 </div>
 
+<% if (it.resultsCapped) { %>
+<div class="panel" style="border-color: var(--orange); background: var(--surface-alt);">
+    <span class="text-orange font-600">&#9888; Results capped:</span> Showing first 2,000 of <%= it.cappedTotal.toLocaleString() %> products. Use filters to narrow results.
+</div>
+<% } %>
+
 <% if (it.error) { %>
 <div class="panel" style="border-color: var(--red);">
     <span class="text-red font-600">Error:</span> <%= it.error %>


### PR DESCRIPTION
## Summary
- Adds `MAX_PRODUCTS = 2000` cap to the /products route's Odoo batch fetch loop
- Displays a warning banner in the UI when results are truncated, showing total count and suggesting filters

## Issues Resolved
- Closes #34 — /products route fetches entire Odoo catalog in unbounded sequential batches

## Changes
- **File:** `packages/listing-processor/src/index.ts` — Added MAX_PRODUCTS constant, capped fetch loop, passes `resultsCapped` and `cappedTotal` to template
- **File:** `packages/listing-processor/templates/products.eta` — Added warning banner for capped results

## Verification
- [x] Build passes (`pnpm build`)
- [x] No unrelated changes
- [x] All resolved issues have `Closes #XX`

## Notes for Reviewer
This is the simplest effective fix. A more thorough approach (server-side pagination pushing limit/offset to Odoo directly) is a larger refactor that could be done as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)