### PR TITLE
Wire @ld/catalog into listing-dashboard (Phase 1)

### DIFF
--- a/lib/catalog/package.json
+++ b/lib/catalog/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@ld/catalog",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Shared product contract between intake-station and listing-dashboard",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "license": "UNLICENSED",
+  "devDependencies": {
+    "@types/node": "^25.2.3"
+  }
+}

--- a/lib/catalog/src/enrichment-blob.ts
+++ b/lib/catalog/src/enrichment-blob.ts
@@ -1,0 +1,96 @@
+// ── Enrichment Blob Parser ────────────────────────────────────────────
+//
+// intake-station writes a JSON blob to Odoo's x_ebay_item_specifics field.
+// This module defines the blob's shape and provides a parser that
+// listing-dashboard uses to safely read it.
+//
+// This is the ONE piece of logic in @ld/catalog — a pure function that
+// validates JSON structure. No side effects, no API calls.
+
+import type { EnrichmentCompleteness } from './product.js';
+
+/**
+ * The shape of the JSON blob stored in Odoo's x_ebay_item_specifics field.
+ * Written by intake-station's enricher.ts (writeEnrichmentToOdoo).
+ *
+ * Example:
+ * ```json
+ * {
+ *   "category": { "id": "177", "name": "Laptops & Netbooks", "breadcrumb": [...] },
+ *   "specifics": { "Brand": "Dell", "Processor": "Intel Core i7-1165G7", ... },
+ *   "requiredUnfilled": ["MPN"],
+ *   "completeness": { "required": { "filled": 5, "total": 6 }, "recommended": { "filled": 8, "total": 14 } },
+ *   "enrichedAt": "2026-03-10T00:00:00.000Z"
+ * }
+ * ```
+ */
+export interface EnrichmentBlob {
+  category: {
+    id: string;
+    name: string;
+    breadcrumb: string[];
+  };
+  specifics: Record<string, string>;
+  requiredUnfilled: string[];
+  completeness: EnrichmentCompleteness;
+  enrichedAt: string;
+}
+
+/**
+ * Parse the raw x_ebay_item_specifics string from Odoo into a typed blob.
+ * Returns null if the input is missing, empty, or malformed.
+ * Never throws — callers should fall back to hardcoded logic on null.
+ */
+export function parseEnrichmentBlob(raw: string | null | undefined | false): EnrichmentBlob | null {
+  if (!raw || typeof raw !== 'string') return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+    // Validate minimum required shape
+    const category = parsed.category as Record<string, unknown> | undefined;
+    if (!category || typeof category.id !== 'string' || typeof category.name !== 'string') {
+      return null;
+    }
+
+    const specifics = parsed.specifics;
+    if (!specifics || typeof specifics !== 'object' || Array.isArray(specifics)) {
+      return null;
+    }
+
+    return {
+      category: {
+        id: category.id as string,
+        name: category.name as string,
+        breadcrumb: Array.isArray(category.breadcrumb)
+          ? (category.breadcrumb as unknown[]).filter((s): s is string => typeof s === 'string')
+          : [],
+      },
+      specifics: Object.fromEntries(
+        Object.entries(specifics as Record<string, unknown>)
+          .filter(([, v]) => typeof v === 'string' && v.trim() !== ''),
+      ) as Record<string, string>,
+      requiredUnfilled: Array.isArray(parsed.requiredUnfilled)
+        ? (parsed.requiredUnfilled as unknown[]).filter((s): s is string => typeof s === 'string')
+        : [],
+      completeness: isCompleteness(parsed.completeness)
+        ? parsed.completeness
+        : { required: { filled: 0, total: 0 }, recommended: { filled: 0, total: 0 } },
+      enrichedAt: typeof parsed.enrichedAt === 'string' ? parsed.enrichedAt : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isCompleteness(v: unknown): v is EnrichmentCompleteness {
+  if (!v || typeof v !== 'object') return false;
+  const c = v as Record<string, unknown>;
+  return isFilledTotal(c.required) && isFilledTotal(c.recommended);
+}
+
+function isFilledTotal(v: unknown): v is { filled: number; total: number } {
+  if (!v || typeof v !== 'object') return false;
+  const ft = v as Record<string, unknown>;
+  return typeof ft.filled === 'number' && typeof ft.total === 'number';
+}

--- a/lib/catalog/src/index.ts
+++ b/lib/catalog/src/index.ts
@@ -1,0 +1,27 @@
+export {
+  type EnrichedProduct,
+  type ItemSpecific,
+  type SpecificSource,
+  type EnrichmentCompleteness,
+  type EbayConditionId,
+  EBAY_CONDITIONS,
+  CONDITION_LABEL_TO_ID,
+} from './product.js';
+
+export {
+  type CategorySuggestion,
+  type TaxonomyAspect,
+} from './taxonomy.js';
+
+export {
+  type EnrichmentBlob,
+  parseEnrichmentBlob,
+} from './enrichment-blob.js';
+
+export {
+  ODOO_ENRICHMENT_FIELDS,
+  type OdooEnrichmentField,
+  ODOO_LISTING_FIELDS,
+  type OdooListingField,
+  ODOO_ALL_FIELDS,
+} from './odoo-fields.js';

--- a/lib/catalog/src/odoo-fields.ts
+++ b/lib/catalog/src/odoo-fields.ts
@@ -1,0 +1,48 @@
+// ── Odoo Field Contract ──────────────────────────────────────────────
+//
+// The canonical list of Odoo custom fields that both intake-station and
+// listing-dashboard agree on. Odoo is the storage layer — these field
+// names are the persistence mapping, not the schema authority.
+//
+// Adding a field here means both projects can read/write it.
+// Removing a field here should trigger a build error in any project
+// that still references it.
+
+/**
+ * Odoo fields written by intake-station's enrichment pipeline.
+ * listing-dashboard reads these to populate the review UI and eBay upload.
+ */
+export const ODOO_ENRICHMENT_FIELDS = [
+  'x_ebay_category_id',
+  'x_ebay_item_specifics',
+  'x_brand',
+  'x_model_name',
+  'x_series',
+  'x_condition',
+  'x_cosmetic_notes',
+  'x_functional_notes',
+] as const;
+
+export type OdooEnrichmentField = typeof ODOO_ENRICHMENT_FIELDS[number];
+
+/**
+ * Odoo fields written by listing-dashboard after eBay upload.
+ * These track the listing lifecycle and are not read by intake-station.
+ */
+export const ODOO_LISTING_FIELDS = [
+  'x_ebay_listing_id',
+  'x_ebay_listing_status',
+  'x_ebay_listing_url',
+  'x_ebay_sold_price',
+  'x_ebay_sold_date',
+] as const;
+
+export type OdooListingField = typeof ODOO_LISTING_FIELDS[number];
+
+/**
+ * All Odoo custom fields used across both systems.
+ */
+export const ODOO_ALL_FIELDS = [
+  ...ODOO_ENRICHMENT_FIELDS,
+  ...ODOO_LISTING_FIELDS,
+] as const;

--- a/lib/catalog/src/product.ts
+++ b/lib/catalog/src/product.ts
@@ -1,0 +1,100 @@
+// ── Enriched Product ─────────────────────────────────────────────────
+//
+// The shared contract between intake-station (producer) and
+// listing-dashboard (consumer). Defines what a fully-enriched product
+// looks like after intake processing.
+//
+// Two layers:
+//   1. Universal fields — same for every item, every category
+//   2. Dynamic item_specifics — determined by eBay category at runtime
+
+/**
+ * A product that has been identified, categorized, and enriched with
+ * eBay-ready data. This is the handoff format between intake-station
+ * (which produces it) and listing-dashboard (which reviews and uploads it).
+ */
+export interface EnrichedProduct {
+  // ── Identity ────────────────────────────────────────────────────
+  sku: string;
+  brand: string;
+  model?: string;
+  series?: string;
+  suggested_name: string;
+
+  // ── Listing content ─────────────────────────────────────────────
+  title: string;
+  description_html: string;
+
+  // ── eBay category (dynamically resolved) ────────────────────────
+  ebay_category_id: string;
+  ebay_category_name: string;
+  ebay_category_breadcrumb: string[];
+
+  // ── Condition ───────────────────────────────────────────────────
+  condition_id: EbayConditionId;
+  condition_description?: string;
+
+  // ── Pricing ─────────────────────────────────────────────────────
+  price: number;
+  cost?: number;
+  currency: string;
+
+  // ── Dynamic item specifics ──────────────────────────────────────
+  item_specifics: ItemSpecific[];
+
+  // ── Enrichment metadata ─────────────────────────────────────────
+  enrichment_completeness?: EnrichmentCompleteness;
+  enriched_at?: string;
+}
+
+/**
+ * A single eBay item specific (aspect). The valid names and allowed values
+ * for each are determined at runtime by querying eBay's Taxonomy API for
+ * the resolved category — they are NOT hardcoded per product type.
+ */
+export interface ItemSpecific {
+  name: string;
+  value: string | string[];
+  source?: SpecificSource;
+}
+
+/**
+ * How a specific's value was determined. Ordered roughly by confidence:
+ * system_script > ai_vision > ai_research > odoo_field > manual
+ */
+export type SpecificSource =
+  | 'system_script'
+  | 'ai_vision'
+  | 'ai_research'
+  | 'manual'
+  | 'odoo_field';
+
+export interface EnrichmentCompleteness {
+  required: { filled: number; total: number };
+  recommended: { filled: number; total: number };
+}
+
+// ── eBay Condition IDs ───────────────────────────────────────────────
+
+export const EBAY_CONDITIONS = {
+  new:                   1000,
+  certified_refurbished: 2000,
+  seller_refurbished:    2500,
+  used:                  3000,
+  for_parts:             7000,
+} as const;
+
+export type EbayConditionId = typeof EBAY_CONDITIONS[keyof typeof EBAY_CONDITIONS];
+
+/**
+ * Maps intake-station's human-readable condition labels to eBay condition IDs.
+ * intake-station writes x_condition as one of these string values;
+ * listing-dashboard needs the numeric eBay condition ID.
+ */
+export const CONDITION_LABEL_TO_ID: Record<string, EbayConditionId> = {
+  'new':       1000,
+  'like_new':  2500,
+  'good':      3000,
+  'fair':      3000,
+  'parts':     7000,
+};

--- a/lib/catalog/src/taxonomy.ts
+++ b/lib/catalog/src/taxonomy.ts
@@ -1,0 +1,40 @@
+// ── eBay Taxonomy API Types ───────────────────────────────────────────
+//
+// Shared type definitions for eBay's Taxonomy REST API responses.
+// Both intake-station and listing-dashboard query the same API and
+// previously defined identical types independently.
+//
+// These types describe eBay's vocabulary — category suggestions and
+// item aspects (what eBay calls the valid specifics for a given category).
+
+/**
+ * A suggested eBay category returned by the Taxonomy API's
+ * get_category_suggestions endpoint.
+ */
+export interface CategorySuggestion {
+  categoryId: string;
+  categoryName: string;
+  breadcrumb: string[];  // root → leaf
+  level: number;
+}
+
+/**
+ * An item aspect (item specific) for a given eBay category, returned by
+ * the Taxonomy API's get_item_aspects_for_category endpoint.
+ *
+ * This describes what eBay WANTS for a category — the aspect name, whether
+ * it's required, whether values must come from a fixed list (SELECTION_ONLY)
+ * or can be free text, and the allowed values if applicable.
+ *
+ * intake-station uses these to build AI fill prompts.
+ * listing-dashboard uses these for value normalization and validation.
+ */
+export interface TaxonomyAspect {
+  name: string;
+  required: boolean;
+  usage: string;        // 'RECOMMENDED' | 'OPTIONAL'
+  dataType: string;     // 'STRING' | 'NUMBER' | 'DATE'
+  mode: string;         // 'FREE_TEXT' | 'SELECTION_ONLY'
+  multiValue: boolean;
+  values: string[];     // allowed values (populated for SELECTION_ONLY)
+}

--- a/lib/catalog/tsconfig.json
+++ b/lib/catalog/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/lib/ebay/package.json
+++ b/lib/ebay/package.json
@@ -10,6 +10,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@ld/catalog": "workspace:*",
     "@ld/odoo-sdk": "workspace:*",
     "fast-xml-parser": "^5.2.3"
   },

--- a/lib/ebay/src/client.ts
+++ b/lib/ebay/src/client.ts
@@ -1,6 +1,7 @@
 import { loadEbayConfig } from './config.js';
 import { EbayApiError, EbayAuthError } from './errors.js';
 import { parseXml, xmlEscape, xmlGet, xmlFindAll, safeCdata } from './xml.js';
+import { EBAY_CONDITIONS } from '@ld/catalog';
 import type {
   EbayConfig, ListingData, AddItemResult, VerifyAddItemResult,
   ReviseItemResult, TestConnectionResult, CategorySpecificsResult,
@@ -202,7 +203,7 @@ export class EbayClient {
         <PrimaryCategory>
             <CategoryID>${data.category_id ?? '177'}</CategoryID>
         </PrimaryCategory>
-        <ConditionID>${data.condition_id ?? '3000'}</ConditionID>
+        <ConditionID>${data.condition_id ?? EBAY_CONDITIONS.used}</ConditionID>
         <ConditionDescription>${xmlEscape(data.condition_description ?? '')}</ConditionDescription>
         <StartPrice currencyID="${currency}">${data.price.toFixed(2)}</StartPrice>
         <Quantity>1</Quantity>

--- a/lib/ebay/src/index.ts
+++ b/lib/ebay/src/index.ts
@@ -4,7 +4,7 @@ export { loadEbayConfig } from './config.js';
 export { EbayApiError, EbayAuthError } from './errors.js';
 export { xmlEscape } from './xml.js';
 export type {
-  EbayConfig, ListingData, ItemSpecific,
+  EbayConfig, ListingData, ItemSpecific, LegacyItemSpecific,
   AddItemResult, VerifyAddItemResult, ReviseItemResult,
   TestConnectionResult, Fee, ApiWarning,
   CategorySpecificsResult, CategoryAspect,

--- a/lib/ebay/src/types.ts
+++ b/lib/ebay/src/types.ts
@@ -1,3 +1,16 @@
+// Re-export the catalog's canonical ItemSpecific type alongside the legacy shape
+export type { ItemSpecific } from '@ld/catalog';
+
+/**
+ * Legacy item-specific shape used throughout listing-dashboard.
+ * Capital-letter keys (Name/Value) match the eBay Trading API XML format.
+ * Phase 2 will migrate consumers to the catalog's lowercase shape.
+ */
+export interface LegacyItemSpecific {
+  Name: string;
+  Value: string;
+}
+
 // ── eBay Config ──────────────────────────────────────────────────────
 
 export interface EbayConfig {
@@ -38,16 +51,11 @@ export interface ListingData {
   location?: string;
   postal_code?: string;
   dispatch_days?: number;
-  item_specifics?: ItemSpecific[];
+  item_specifics?: LegacyItemSpecific[];
   // Inline policy fields (fallback when no business policies)
   returns_accepted?: boolean;
   return_days?: number;
   shipping_cost?: number;
-}
-
-export interface ItemSpecific {
-  Name: string;
-  Value: string;
 }
 
 // ── API Responses ────────────────────────────────────────────────────
@@ -177,6 +185,6 @@ export interface EbayItemDetail {
   quantityAvailable: number;
   listingDetails: EbayListingDetails;
   sellingStatus: EbaySellingStatus;
-  itemSpecifics: ItemSpecific[];
+  itemSpecifics: LegacyItemSpecific[];
   pictureURLs: string[];
 }

--- a/packages/listing-processor/package.json
+++ b/packages/listing-processor/package.json
@@ -15,6 +15,7 @@
     "@fastify/cors": "^11.0.0",
     "@fastify/formbody": "^8.0.2",
     "@fastify/static": "^8.1.0",
+    "@ld/catalog": "workspace:*",
     "@ld/db": "workspace:*",
     "@ld/ebay-client": "workspace:*",
     "@ld/odoo-sdk": "workspace:*",

--- a/packages/listing-processor/src/field-mapper.ts
+++ b/packages/listing-processor/src/field-mapper.ts
@@ -5,16 +5,18 @@ import { cleanProcessorString } from './value-matcher.js';
 
 import type { OdooProduct, OdooImage } from '@ld/odoo-sdk';
 import { xmlEscape } from '@ld/ebay-client';
-import type { ListingData, ItemSpecific } from './normalizer.js';
+import type { ListingData } from './normalizer.js';
+import type { LegacyItemSpecific } from './normalizer.js';
+import { EBAY_CONDITIONS } from '@ld/catalog';
 
 // ── Constants ────────────────────────────────────────────────────────
 
 export const EBAY_CATEGORY_LAPTOP = '177';
 
-export const EBAY_CONDITION_USED = '3000';
-export const EBAY_CONDITION_REFURBISHED_SELLER = '2500';
-export const EBAY_CONDITION_REFURBISHED_CERTIFIED = '2000';
-export const EBAY_CONDITION_NEW = '1000';
+export const EBAY_CONDITION_USED = String(EBAY_CONDITIONS.used);
+export const EBAY_CONDITION_REFURBISHED_SELLER = String(EBAY_CONDITIONS.seller_refurbished);
+export const EBAY_CONDITION_REFURBISHED_CERTIFIED = String(EBAY_CONDITIONS.certified_refurbished);
+export const EBAY_CONDITION_NEW = String(EBAY_CONDITIONS.new);
 
 export const STORAGE_TYPE_DISPLAY: Record<string, string> = {
   nvme: 'NVMe (Non-Volatile Memory Express)',
@@ -108,8 +110,8 @@ function buildTitle(product: OdooProduct): string {
 
 // ── Item Specifics Builder ──────────────────────────────────────────
 
-function buildItemSpecifics(product: OdooProduct): ItemSpecific[] {
-  const specifics: ItemSpecific[] = [];
+function buildItemSpecifics(product: OdooProduct): LegacyItemSpecific[] {
+  const specifics: LegacyItemSpecific[] = [];
   const add = (name: string, value: string | null) => {
     if (value) specifics.push({ Name: name, Value: value });
   };

--- a/packages/listing-processor/src/normalizer.ts
+++ b/packages/listing-processor/src/normalizer.ts
@@ -225,7 +225,15 @@ export function sanitizeDescriptionHtml(html: string): string {
 
 // ── Item Specifics Normalization ────────────────────────────────────
 
-export interface ItemSpecific {
+// Re-export the catalog's canonical ItemSpecific type
+export type { ItemSpecific } from '@ld/catalog';
+
+/**
+ * Legacy item-specific shape used throughout listing-dashboard.
+ * Capital-letter keys (Name/Value) match the eBay Trading API XML format.
+ * Phase 2 will migrate consumers to the catalog's lowercase shape.
+ */
+export interface LegacyItemSpecific {
   Name: string;
   Value: string;
 }
@@ -234,10 +242,10 @@ export function normalizeItemSpecifics(
   itemSpecifics: unknown[],
   allowedNames?: Set<string>,
   valueOptionsByName?: Record<string, string[]>,
-): ItemSpecific[] {
+): LegacyItemSpecific[] {
   if (!Array.isArray(itemSpecifics)) return [];
 
-  const normalized: ItemSpecific[] = [];
+  const normalized: LegacyItemSpecific[] = [];
   const seen = new Set<string>();
 
   for (const raw of itemSpecifics) {
@@ -251,7 +259,7 @@ export function normalizeItemSpecifics(
     const normalizedValue = normalizeSpecificValue(name, value, valueOptionsByName);
     if (!normalizedValue) continue;
 
-    const entry: ItemSpecific = {
+    const entry: LegacyItemSpecific = {
       Name: truncateReadable(name, 65),
       Value: truncateReadable(normalizedValue, 120),
     };
@@ -284,7 +292,7 @@ export interface ListingData {
   currency?: string;
   quantity?: number;
   listing_duration?: string;
-  item_specifics: ItemSpecific[];
+  item_specifics: LegacyItemSpecific[];
   description_html: string;
   image_urls?: string[];
   image_count?: number;
@@ -372,7 +380,7 @@ export function listingQualityWarnings(listingData: ListingData): string[] {
 
   const specificNames = new Set(
     specifics
-      .filter((s): s is ItemSpecific => typeof s === 'object' && s !== null)
+      .filter((s): s is LegacyItemSpecific => typeof s === 'object' && s !== null)
       .map(s => (s.Name ?? '').trim().toLowerCase())
   );
   const missingCore = [...CORE_SPECIFIC_NAMES].filter(n => !specificNames.has(n)).sort();
@@ -428,7 +436,7 @@ export function applyListingFormOverrides(
   if (form.spec_count) {
     const count = parseInt(form.spec_count, 10);
     if (count > 0) {
-      const specs: ItemSpecific[] = [];
+      const specs: LegacyItemSpecific[] = [];
       for (let i = 0; i < count; i++) {
         const name = form[`spec_name_${i}`];
         const value = form[`spec_value_${i}`];

--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -11,6 +11,7 @@
     "dev": "node --watch dist/index.js"
   },
   "dependencies": {
+    "@ld/catalog": "workspace:*",
     "@ld/db": "workspace:*",
     "@ld/odoo-sdk": "workspace:*",
     "@ld/ebay-client": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .: {}
 
+  lib/catalog:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.3.5
+
   lib/db:
     dependencies:
       better-sqlite3:
@@ -23,6 +29,9 @@ importers:
 
   lib/ebay:
     dependencies:
+      '@ld/catalog':
+        specifier: workspace:*
+        version: link:../catalog
       '@ld/odoo-sdk':
         specifier: workspace:*
         version: link:../odoo
@@ -54,6 +63,9 @@ importers:
       '@fastify/static':
         specifier: ^8.1.0
         version: 8.3.0
+      '@ld/catalog':
+        specifier: workspace:*
+        version: link:../../lib/catalog
       '@ld/db':
         specifier: workspace:*
         version: link:../../lib/db
@@ -91,6 +103,9 @@ importers:
       '@fastify/cors':
         specifier: ^11.0.0
         version: 11.2.0
+      '@ld/catalog':
+        specifier: workspace:*
+        version: link:../../lib/catalog
       '@ld/db':
         specifier: workspace:*
         version: link:../../lib/db


### PR DESCRIPTION
## Summary

- Added `@ld/catalog` as a workspace dependency to `listing-processor`, `upload-api`, and `lib/ebay`
- Replaced duplicate `ItemSpecific` interfaces in `lib/ebay/src/types.ts` and `normalizer.ts` with re-exports from `@ld/catalog`, introducing `LegacyItemSpecific` to preserve the existing `{ Name, Value }` shape for Phase 1
- Replaced hardcoded eBay condition-ID magic numbers (`1000`/`2000`/`2500`/`3000`) in `field-mapper.ts` and `client.ts` with `EBAY_CONDITIONS` imports from `@ld/catalog`

Pure refactor -- no runtime behavior changes. `pnpm build` passes clean.

## Quality Gate

- [x] `pnpm build` passes with zero errors
- [x] No magic condition numbers (1000/2000/2500/3000/7000) remain as string/number literals in TypeScript source files (only in `@ld/catalog` where they are defined)
- [x] Existing consumers continue to use the `LegacyItemSpecific` shape with capital `Name`/`Value` keys -- no shape migration yet (that is Phase 2)

## Test plan

- [x] Verify `pnpm build` passes across all workspace packages
- [ ] Verify runtime behavior is unchanged: start listing-processor and upload-api, confirm listings process and upload identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)