### PR TITLE
[Fix] Pass default condition description to all finalizeListingData call sites

### DIFF
--- a/packages/listing-processor/src/index.ts
+++ b/packages/listing-processor/src/index.ts
@@ -171,7 +171,8 @@ function listingDataFromSavedOnly(
   data.condition_description ??= '';
   data.description_html ??= '';
   data.item_specifics ??= [];
-  return finalizeListingData(data);
+  const ebayConfig = loadEbayAppConfig();
+  return finalizeListingData(data, undefined, ebayConfig.default_condition_description);
 }
 
 // ── Description Sanitization ────────────────────────────────────────
@@ -397,9 +398,10 @@ app.get<{ Params: { productId: string } }>('/products/:productId/preview', async
     const { existing, savedData } = getExistingListing(productId);
     let listingData = mergeSavedListingData(productToListing(product, images), savedData);
 
+    const ebayConfig = loadEbayAppConfig();
     const categoryId = String(listingData.category_id ?? EBAY_CATEGORY_LAPTOP);
     const specificOptions = await getCategorySpecificOptions(categoryId);
-    listingData = finalizeListingData(listingData, specificOptions);
+    listingData = finalizeListingData(listingData, specificOptions, ebayConfig.default_condition_description);
     listingData = sanitizeListingHtml(listingData);
     const qualityWarnings = listingQualityWarnings(listingData);
 
@@ -505,9 +507,9 @@ app.post<{ Params: { productId: string } }>('/products/:productId/edit', async (
     const images = await getProductImages(odoo, productId);
     const { existing, savedData } = getExistingListing(productId);
     let listingData = mergeSavedListingData(productToListing(product, images), savedData);
-    listingData = finalizeListingData(listingData);
-
     const ebayConfig = loadEbayAppConfig();
+    listingData = finalizeListingData(listingData, undefined, ebayConfig.default_condition_description);
+
     const categoryId = String((req.body as Record<string, string>).category_id ?? listingData.category_id ?? EBAY_CATEGORY_LAPTOP);
     const categoryOptions = await getCategorySpecificOptions(categoryId);
     listingData = applyListingFormOverrides(
@@ -545,7 +547,6 @@ app.post<{ Params: { productId: string } }>('/products/:productId/save-changes',
         if (product) {
           const images = await getProductImages(odoo, productId);
           listingData = mergeSavedListingData(productToListing(product, images), savedData);
-          listingData = finalizeListingData(listingData);
         }
       } catch (err) {
         console.warn(`save-changes: Odoo fetch failed for product ${productId}:`, err);
@@ -558,6 +559,7 @@ app.post<{ Params: { productId: string } }>('/products/:productId/save-changes',
     }
 
     const ebayConfig = loadEbayAppConfig();
+    listingData = finalizeListingData(listingData, undefined, ebayConfig.default_condition_description);
     const categoryId = String((req.body as Record<string, string>).category_id ?? listingData.category_id ?? EBAY_CATEGORY_LAPTOP);
     const categoryOptions = await getCategorySpecificOptions(categoryId);
     listingData = applyListingFormOverrides(
@@ -605,7 +607,6 @@ app.post<{ Params: { productId: string } }>('/products/:productId/revise-ebay', 
         if (product) {
           const images = await getProductImages(odoo, productId);
           listingData = mergeSavedListingData(productToListing(product, images), savedData);
-          listingData = finalizeListingData(listingData);
         }
       } catch (err) {
         console.warn(`revise-ebay: Odoo fetch failed for product ${productId}:`, err);
@@ -618,6 +619,7 @@ app.post<{ Params: { productId: string } }>('/products/:productId/revise-ebay', 
     }
 
     const ebayConfig = loadEbayAppConfig();
+    listingData = finalizeListingData(listingData, undefined, ebayConfig.default_condition_description);
     const categoryId = String((req.body as Record<string, string>).category_id ?? listingData.category_id ?? EBAY_CATEGORY_LAPTOP);
     const categoryOptions = await getCategorySpecificOptions(categoryId);
     listingData = applyListingFormOverrides(


### PR DESCRIPTION
## Summary
The `default_condition_description` configured in Settings was saved correctly but never applied to listing data. All 5 `finalizeListingData()` call sites omitted the third parameter, so the fallback never fired and condition description was always empty on first preview.

## Issues Resolved
- Closes #49 — Default condition description never applied to listing previews

## Changes
- **File:** `packages/listing-processor/src/index.ts`
- **What changed:** Pass `loadEbayAppConfig().default_condition_description` to all 5 `finalizeListingData()` call sites:
  - `listingDataFromSavedOnly()` helper (line 174)
  - Preview route GET `/products/:productId/preview` (line 402)
  - Edit route POST `/products/:productId/edit` (line 508)
  - Save-changes route POST `/products/:productId/save-changes` (line 548)
  - Revise-ebay route POST `/products/:productId/revise-ebay` (line 608)
- For save-changes and revise-ebay, moved the intermediate `finalizeListingData` call after `loadEbayAppConfig()` to avoid redundant config loads

## Verification
- [x] Build passes (`pnpm build`)
- [x] No unrelated changes
- [x] All resolved issues have `Closes #XX`
- [x] Manual form override still takes precedence (line 416 in `applyListingFormOverrides` sets `condition_description` from form input before `finalizeListingData` checks the fallback)

## Notes for Reviewer
The issue suggested `applyListingFormOverrides`'s `defaultConditionDescription` param was dead code, but it's actually passed through to `finalizeListingData` on line 449 — so it was already working correctly for approve/edit/save-changes/revise routes. The real gap was the preview route (which never calls `applyListingFormOverrides`) and the `listingDataFromSavedOnly` fallback helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)