### PR TITLE
[Enhance] Readiness-oriented product table redesign

### DIFF
--- a/packages/listing-processor/src/index.ts
+++ b/packages/listing-processor/src/index.ts
@@ -244,7 +244,7 @@ app.get('/', async (req, reply) => {
 
 // ── Routes: Products ────────────────────────────────────────────────
 
-app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; status?: string } }>(
+app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; status?: string; photos?: string } }>(
   '/products',
   async (req, reply) => {
     const LISTING_STATUSES = ['draft', 'approved', 'rejected', 'uploading', 'uploaded', 'failed'] as const;
@@ -254,19 +254,23 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
       ...LISTING_STATUSES.map(s => [s, s.charAt(0).toUpperCase() + s.slice(1)]),
     ];
 
+    const emptyState = (extra: Record<string, unknown> = {}) => ({
+      products: [], error: extra.error ?? null,
+      page: 1, totalPages: 0, total: 0, scanFilter: 'all', photoFilter: 'all',
+      countAll: 0, countScanned: 0, countUnscanned: 0, currentScanTotal: 0,
+      countWithPhotos: 0, countNoPhotos: 0,
+      listedCount: 0, perPage: 100, perPageOptions: PER_PAGE_OPTIONS,
+      listingFilter: 'all', listingFilterOptions,
+      statusCounts: Object.fromEntries([...LISTING_STATUSES, 'unlisted'].map(s => [s, 0])),
+      activeNav: 'products',
+      ...extra,
+    });
+
     const odoo = getOdoo();
     if (!odoo) {
       flash(reply, 'error', 'Cannot connect to Odoo');
       reply.type('text/html');
-      return render(req, reply, 'products', {
-        products: [], error: 'Cannot connect to Odoo',
-        page: 1, totalPages: 0, total: 0, scanFilter: 'all',
-        countAll: 0, countScanned: 0, countUnscanned: 0, currentScanTotal: 0,
-        listedCount: 0, perPage: 100, perPageOptions: PER_PAGE_OPTIONS,
-        listingFilter: 'all', listingFilterOptions,
-        statusCounts: Object.fromEntries([...LISTING_STATUSES, 'unlisted'].map(s => [s, 0])),
-        activeNav: 'products',
-      });
+      return render(req, reply, 'products', emptyState({ error: 'Cannot connect to Odoo' }));
     }
 
     let page = Math.max(parseInt(req.query.page ?? '1', 10) || 1, 1);
@@ -275,6 +279,7 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
     const scanFilter = ['all', 'scanned', 'unscanned'].includes(req.query.filter ?? '') ? req.query.filter! : 'all';
     const validStatuses = new Set(['all', 'unlisted', ...LISTING_STATUSES]);
     const listingFilter = validStatuses.has(req.query.status ?? '') ? req.query.status! : 'all';
+    const photoFilter = ['all', 'has_photos', 'no_photos'].includes(req.query.photos ?? '') ? req.query.photos! : 'all';
 
     try {
       const scanDomain = (f: string) => {
@@ -305,6 +310,12 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
       const productIds = allProducts.map(p => p.id);
       const listingByProductId = getListingProductIds(db, productIds);
 
+      // Fetch image counts for ALL products (before filtering) to support photo filter
+      let allImageCounts = new Map<number, number>();
+      try {
+        allImageCounts = await getProductImageCounts(odoo, productIds);
+      } catch { /* ignore */ }
+
       const statusCounts: Record<string, number> = Object.fromEntries(
         [...LISTING_STATUSES, 'unlisted'].map(s => [s, 0])
       );
@@ -314,6 +325,8 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
         const listingStatus = listing?.status ?? null;
         const listingId = listing?.id ?? null;
         const hasSpecs = !!p.x_processor;
+        const hasEnrichment = !!p.x_ebay_category_id;
+        const imageCount = allImageCounts.get(p.id) ?? 0;
 
         if (listingStatus && listingStatus in statusCounts) {
           statusCounts[listingStatus]!++;
@@ -321,7 +334,7 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
           statusCounts.unlisted!++;
         }
 
-        return { ...p, listing_status: listingStatus, listing_id: listingId, has_specs: hasSpecs, image_count: 0 };
+        return { ...p, listing_status: listingStatus, listing_id: listingId, has_specs: hasSpecs, has_enrichment: hasEnrichment, image_count: imageCount };
       });
 
       // Filter by listing status
@@ -332,19 +345,27 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
         filteredProducts = enriched.filter(p => p.listing_status === listingFilter);
       }
 
+      // Filter by photo status
+      if (photoFilter === 'has_photos') {
+        filteredProducts = filteredProducts.filter(p => p.image_count > 0);
+      } else if (photoFilter === 'no_photos') {
+        filteredProducts = filteredProducts.filter(p => p.image_count === 0);
+      }
+
+      // Photo counts (computed from the listing-filtered set, before photo filter)
+      const listingFiltered = listingFilter === 'unlisted'
+        ? enriched.filter(p => !p.listing_status)
+        : LISTING_STATUSES.includes(listingFilter as any)
+          ? enriched.filter(p => p.listing_status === listingFilter)
+          : enriched;
+      const countWithPhotos = listingFiltered.filter(p => p.image_count > 0).length;
+      const countNoPhotos = listingFiltered.filter(p => p.image_count === 0).length;
+
       const total = filteredProducts.length;
       const totalPages = Math.ceil(total / perPage) || 0;
       if (totalPages > 0 && page > totalPages) page = totalPages;
       const offset = (page - 1) * perPage;
       const productList = filteredProducts.slice(offset, offset + perPage);
-
-      // Get image counts
-      try {
-        const imageCounts = await getProductImageCounts(odoo, productList.map(p => p.id));
-        for (const p of productList) {
-          p.image_count = imageCounts.get(p.id) ?? 0;
-        }
-      } catch { /* ignore */ }
 
       let listedCount = 0;
       for (const p of productList) {
@@ -354,7 +375,8 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
       reply.type('text/html');
       return render(req, reply, 'products', {
         products: productList, page, totalPages, total,
-        scanFilter, countAll, countScanned, countUnscanned,
+        scanFilter, photoFilter, countAll, countScanned, countUnscanned,
+        countWithPhotos, countNoPhotos,
         currentScanTotal: filteredScanTotal, listedCount,
         perPage, perPageOptions: PER_PAGE_OPTIONS,
         listingFilter, listingFilterOptions, statusCounts,
@@ -364,15 +386,7 @@ app.get<{ Querystring: { page?: string; per_page?: string; filter?: string; stat
     } catch (err) {
       flash(reply, 'error', `Odoo error: ${(err as Error).message}`);
       reply.type('text/html');
-      return render(req, reply, 'products', {
-        products: [], error: (err as Error).message,
-        page: 1, totalPages: 0, total: 0, scanFilter,
-        countAll: 0, countScanned: 0, countUnscanned: 0, currentScanTotal: 0,
-        listedCount: 0, perPage, perPageOptions: PER_PAGE_OPTIONS,
-        listingFilter, listingFilterOptions,
-        statusCounts: Object.fromEntries([...LISTING_STATUSES, 'unlisted'].map(s => [s, 0])),
-        activeNav: 'products',
-      });
+      return render(req, reply, 'products', emptyState({ error: (err as Error).message, scanFilter, photoFilter, perPage }));
     }
   },
 );

--- a/packages/listing-processor/static/style.css
+++ b/packages/listing-processor/static/style.css
@@ -438,6 +438,32 @@ td.truncate {
 .nowrap { white-space: nowrap; }
 .cost { color: var(--red); }
 .price { color: var(--green); font-weight: 600; }
+/* -- Readiness dots -- */
+.ready-dots {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+.ready-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.dot-ok { background: var(--green); }
+.dot-off { background: var(--border-muted); }
+/* -- Photo count -- */
+.photo-count {
+  display: inline-block;
+  min-width: 18px;
+  text-align: center;
+  font-weight: 600;
+  font-size: var(--fs-sm);
+  padding: 0 3px;
+}
+.photo-ok { color: var(--green); }
+.photo-missing { color: var(--red); opacity: 0.7; }
+
 .warn-row td { background: var(--yellow-subtle) !important; }
 .err-row td { background: var(--red-subtle) !important; }
 .hidden { display: none; }

--- a/packages/listing-processor/templates/products.eta
+++ b/packages/listing-processor/templates/products.eta
@@ -2,12 +2,20 @@
 
 <div class="page-header">
     <h2>Products <span class="text-muted text-md">(<%= it.total %>)</span></h2>
-    <span class="text-sm text-muted">Odoo inventory &mdash; filter by scan + listing status</span>
+    <span class="text-sm text-muted">Odoo inventory &mdash; filter by photos, scan + listing status</span>
 </div>
 
 <form method="get" class="products-controls">
     <div class="form-group">
-        <label for="scan-filter">Scan Filter</label>
+        <label for="photo-filter">Photos</label>
+        <select id="photo-filter" name="photos">
+            <option value="all" <%= it.photoFilter === 'all' ? 'selected' : '' %>>All</option>
+            <option value="has_photos" <%= it.photoFilter === 'has_photos' ? 'selected' : '' %>>Has Photos (<%= it.countWithPhotos %>)</option>
+            <option value="no_photos" <%= it.photoFilter === 'no_photos' ? 'selected' : '' %>>No Photos (<%= it.countNoPhotos %>)</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <label for="scan-filter">Scan</label>
         <select id="scan-filter" name="filter">
             <option value="all" <%= it.scanFilter === 'all' ? 'selected' : '' %>>All (<%= it.countAll %>)</option>
             <option value="scanned" <%= it.scanFilter === 'scanned' ? 'selected' : '' %>>Scanned (<%= it.countScanned %>)</option>
@@ -40,7 +48,7 @@
 
 <div class="filter-pills">
     <% for (const [statusKey, statusLabel] of it.listingFilterOptions) { %>
-    <a href="/products?filter=<%= it.scanFilter %>&status=<%= statusKey %>&per_page=<%= it.perPage %>&page=1"
+    <a href="/products?filter=<%= it.scanFilter %>&photos=<%= it.photoFilter %>&status=<%= statusKey %>&per_page=<%= it.perPage %>&page=1"
        class="filter-pill<%= it.listingFilter === statusKey ? ' active' : '' %>">
         <%= statusLabel %>
         <span class="filter-pill-count">
@@ -62,21 +70,20 @@
 </div>
 <% } else if (it.products.length === 0) { %>
 <div class="panel text-muted">
-    No products found for this scan/status filter combination.
+    No products found for this filter combination.
 </div>
 <% } else { %>
 <div class="overflow-auto">
     <table>
         <thead>
             <tr>
-                <th>ID</th><th>Ref</th><th>Name</th><th>Brand / Model</th><th>Processor</th>
-                <th>RAM</th><th>Storage</th><th>Screen</th><th>Cost</th>
-                <th>Price</th><th>Img</th><th>Status</th><th></th>
+                <th>ID</th><th>Ref</th><th>Name</th><th>Brand / Model</th>
+                <th>Cost</th><th>Price</th><th>Photos</th><th>Ready</th><th>Status</th><th></th>
             </tr>
         </thead>
         <tbody>
             <% for (const p of it.products) { %>
-            <tr<%= !p.has_specs ? ' style="opacity: 0.55;"' : (p.image_count === 0 ? ' class="warn-row"' : '') %>>
+            <tr>
                 <td><%= p.id %></td>
                 <td class="text-xs"><%= p.default_code || '-' %></td>
                 <td class="text-xs"><%= p.name || p.default_code || '-' %></td>
@@ -84,31 +91,21 @@
                     <strong><%= p.x_brand || '?' %></strong><% if (p.x_series) { %> <span class="text-muted"><%= p.x_series %></span><% } %>
                     <% if (p.x_model_name) { %><br><span class="text-xs text-muted"><%= p.x_model_name %></span><% } %>
                 </td>
-                <td class="text-xs">
-                    <% if (p.x_processor) { %>
-                    <%= p.x_processor %>
-                    <% if (p.x_processor_speed) { %><br><span class="text-muted"><%= p.x_processor_speed %></span><% } %>
-                    <% } else { %>
-                    <span class="text-orange" title="Needs boot USB scan">&mdash; not scanned</span>
-                    <% } %>
-                </td>
-                <td><%= p.x_ram_size || '-' %></td>
-                <td class="text-xs">
-                    <%= p.x_storage_capacity || '-' %>
-                    <% if (p.x_storage_type) { %><br><span class="text-muted"><%= p.x_storage_type %></span><% } %>
-                </td>
-                <td class="text-xs">
-                    <%= p.x_screen_size || '-' %>
-                    <% if (p.x_max_resolution) { %><br><span class="text-muted"><%= p.x_max_resolution %></span><% } %>
-                </td>
                 <td class="num cost"><% if (p.standard_price) { %>$<%= Math.round(p.standard_price) %><% } else { %>-<% } %></td>
                 <td class="num price"><% if (p.list_price) { %>$<%= Math.round(p.list_price) %><% } else { %>-<% } %></td>
                 <td class="text-center">
                     <% if (p.image_count > 0) { %>
-                    <span class="text-green"><%= p.image_count %></span>
+                    <span class="photo-count photo-ok"><%= p.image_count %></span>
                     <% } else { %>
-                    <span class="text-orange font-bold" title="No photos">!</span>
+                    <span class="photo-count photo-missing" title="No photos uploaded">0</span>
                     <% } %>
+                </td>
+                <td>
+                    <span class="ready-dots" title="Scanned / Photos / Enriched">
+                        <span class="ready-dot <%= p.has_specs ? 'dot-ok' : 'dot-off' %>" title="<%= p.has_specs ? 'Scanned' : 'Not scanned' %>"></span>
+                        <span class="ready-dot <%= p.image_count > 0 ? 'dot-ok' : 'dot-off' %>" title="<%= p.image_count > 0 ? p.image_count + ' photos' : 'No photos' %>"></span>
+                        <span class="ready-dot <%= p.has_enrichment ? 'dot-ok' : 'dot-off' %>" title="<%= p.has_enrichment ? 'Enriched' : 'Not enriched' %>"></span>
+                    </span>
                 </td>
                 <td>
                     <% if (p.listing_status) { %>
@@ -116,7 +113,7 @@
                     <% } else if (p.has_specs) { %>
                     <span class="badge badge-new">new</span>
                     <% } else { %>
-                    <span class="badge" style="background: var(--surface-alt); color: var(--text-3); border: 1px solid var(--border-muted);">needs scan</span>
+                    <span class="text-xs text-muted">needs scan</span>
                     <% } %>
                 </td>
                 <td><a href="/products/<%= p.id %>/preview" class="btn btn-primary btn-sm">Preview</a></td>
@@ -137,7 +134,7 @@
 <% if (it.totalPages > 1) { %>
 <div class="pagination">
     <% for (let p = 1; p <= it.totalPages; p++) { %>
-    <a href="/products?page=<%= p %>&filter=<%= it.scanFilter %>&status=<%= it.listingFilter %>&per_page=<%= it.perPage %>" <%= p === it.page ? 'class="active"' : '' %>><%= p %></a>
+    <a href="/products?page=<%= p %>&filter=<%= it.scanFilter %>&photos=<%= it.photoFilter %>&status=<%= it.listingFilter %>&per_page=<%= it.perPage %>" <%= p === it.page ? 'class="active"' : '' %>><%= p %></a>
     <% } %>
 </div>
 <% } %>


### PR DESCRIPTION
## Summary
- Redesigns the product directory table around **workflow readiness** (photos, enrichment status) instead of raw device specs
- Adds photo filter dropdown and ready-dots column for at-a-glance listing prioritization
- Removes visual noise: no more 55% opacity on unscanned rows or styled "needs scan" badges

## Issues Resolved
- Closes #51 — readiness-oriented product table redesign

## Changes

**`packages/listing-processor/templates/products.eta`**
- Removed columns: Processor, RAM, Storage, Screen
- Added columns: Photos (green/red count), Ready (3 dots: scanned/photos/enriched)
- Added photo filter dropdown (All / Has Photos / No Photos)
- "needs scan" now renders as plain muted text instead of styled badge
- Removed `style="opacity: 0.55;"` on unscanned rows and `class="warn-row"` on no-photo rows
- Pagination and filter pill links now preserve `photos` query param

**`packages/listing-processor/src/index.ts`**
- Added `photos` query parameter parsing and validation
- Moved image count fetching before pagination to enable photo-based filtering
- Added `has_enrichment` field (checks `x_ebay_category_id`) to product enrichment
- Added photo filter logic (has_photos / no_photos)
- Computed `countWithPhotos` / `countNoPhotos` from listing-filtered set
- Extracted `emptyState()` helper to DRY up error/empty state rendering

**`packages/listing-processor/static/style.css`**
- Added `.ready-dots` / `.ready-dot` / `.dot-ok` / `.dot-off` styles
- Added `.photo-count` / `.photo-ok` / `.photo-missing` styles

## Verification
- [x] Build passes (`pnpm build`)
- [x] No unrelated changes (ai-generator.ts, settings.eta changes excluded)
- [x] All resolved issues have `Closes #XX`

## Notes for Reviewer
Image counts are now fetched for all products in the scan-filtered set (up to 2000) before pagination, which enables photo filtering but adds one batch RPC call. This is acceptable since `batchCountAttachments` is a single Odoo search_read call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)