### PR TITLE
[Fix] Multi-value item specifics split into separate eBay values

### DIFF
--- a/lib/catalog/src/enrichment-blob.ts
+++ b/lib/catalog/src/enrichment-blob.ts
@@ -30,7 +30,7 @@ export interface EnrichmentBlob {
     name: string;
     breadcrumb: string[];
   };
-  specifics: Record<string, string>;
+  specifics: Record<string, string | string[]>;
   requiredUnfilled: string[];
   completeness: EnrichmentCompleteness;
   enrichedAt: string;
@@ -68,8 +68,12 @@ export function parseEnrichmentBlob(raw: string | null | undefined | false): Enr
       },
       specifics: Object.fromEntries(
         Object.entries(specifics as Record<string, unknown>)
-          .filter(([, v]) => typeof v === 'string' && v.trim() !== ''),
-      ) as Record<string, string>,
+          .filter(([, v]) =>
+            (typeof v === 'string' && v.trim() !== '') ||
+            (Array.isArray(v) && v.length > 0 && v.every(item => typeof item === 'string')),
+          )
+          .map(([k, v]) => [k, Array.isArray(v) ? v.filter((s: string) => s.trim() !== '') : v]),
+      ) as Record<string, string | string[]>,
       requiredUnfilled: Array.isArray(parsed.requiredUnfilled)
         ? (parsed.requiredUnfilled as unknown[]).filter((s): s is string => typeof s === 'string')
         : [],

--- a/lib/ebay/src/client.ts
+++ b/lib/ebay/src/client.ts
@@ -179,9 +179,20 @@ export class EbayClient {
   // ── Listing XML builder ──────────────────────────────────────────────
 
   private buildItemXml(data: ListingData, imageUrls: string[], callName: string): string {
-    const specificsXml = (data.item_specifics ?? []).map(s =>
-      `\n            <NameValueList>\n                <Name>${xmlEscape(s.Name)}</Name>\n                <Value>${xmlEscape(s.Value)}</Value>\n            </NameValueList>`
-    ).join('');
+    // Group item specifics by name for multi-value support
+    const specGroups = new Map<string, string[]>();
+    for (const s of data.item_specifics ?? []) {
+      const existing = specGroups.get(s.Name);
+      if (existing) {
+        existing.push(s.Value);
+      } else {
+        specGroups.set(s.Name, [s.Value]);
+      }
+    }
+    const specificsXml = [...specGroups.entries()].map(([name, values]) => {
+      const valuesXml = values.map(v => `\n                <Value>${xmlEscape(v)}</Value>`).join('');
+      return `\n            <NameValueList>\n                <Name>${xmlEscape(name)}</Name>${valuesXml}\n            </NameValueList>`;
+    }).join('');
 
     const picturesXml = imageUrls.map(url =>
       `\n            <PictureURL>${xmlEscape(url)}</PictureURL>`

--- a/packages/listing-processor/src/field-mapper.ts
+++ b/packages/listing-processor/src/field-mapper.ts
@@ -116,7 +116,13 @@ function buildEnrichedItemSpecifics(product: OdooProduct): LegacyItemSpecific[] 
 
   const specifics: LegacyItemSpecific[] = [];
   for (const [name, value] of Object.entries(blob.specifics)) {
-    if (value) specifics.push({ Name: name, Value: value });
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        if (v) specifics.push({ Name: name, Value: v });
+      }
+    } else if (value) {
+      specifics.push({ Name: name, Value: value });
+    }
   }
   return specifics;
 }

--- a/packages/listing-processor/src/normalizer.ts
+++ b/packages/listing-processor/src/normalizer.ts
@@ -256,18 +256,23 @@ export function normalizeItemSpecifics(
     if (!name || !value) continue;
     if (PLACEHOLDER_SPECIFIC_VALUES.has(value.toLowerCase())) continue;
 
-    const normalizedValue = normalizeSpecificValue(name, value, valueOptionsByName);
-    if (!normalizedValue) continue;
+    const truncatedName = truncateReadable(name, 65);
+    const parts = value.split(/[;,]/).map(s => s.trim()).filter(Boolean);
 
-    const entry: LegacyItemSpecific = {
-      Name: truncateReadable(name, 65),
-      Value: truncateReadable(normalizedValue, 120),
-    };
+    for (const part of parts) {
+      const normalizedValue = normalizeSpecificValue(name, part, valueOptionsByName);
+      if (!normalizedValue) continue;
 
-    const key = `${entry.Name.toLowerCase()}|${entry.Value.toLowerCase()}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    normalized.push(entry);
+      const entry: LegacyItemSpecific = {
+        Name: truncatedName,
+        Value: truncateReadable(normalizedValue, 65),
+      };
+
+      const key = `${entry.Name.toLowerCase()}|${entry.Value.toLowerCase()}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      normalized.push(entry);
+    }
   }
 
   return normalized;


### PR DESCRIPTION
## Summary
- Fixes the pipeline-wide gap where multi-value eBay item specifics (Features, Connectivity, etc.) were submitted as a single concatenated string, causing 65-char limit rejections
- Addresses root causes RC1, RC2, RC3, RC4, and RC6 from the Phase 1 fix strategy

## Issues Resolved
- Closes #55 — Multi-value item specifics not split into separate eBay values

## Changes
- **`lib/catalog/src/enrichment-blob.ts`** — RC1: Changed `specifics` schema from `Record<string, string>` to `Record<string, string | string[]>` to support multi-value aspects. Updated parser to accept and validate string arrays.
- **`packages/listing-processor/src/field-mapper.ts`** — RC2: `buildEnrichedItemSpecifics()` now creates separate `LegacyItemSpecific` entries for each element in array-valued specifics.
- **`packages/listing-processor/src/normalizer.ts`** — RC3+RC4: Per-value truncation limit corrected from 120→65 chars. Added delimiter-aware splitting on `;` and `,` to break concatenated values into individual entries (safety net for legacy data).
- **`lib/ebay/src/client.ts`** — RC6: XML builder groups same-name item specifics into a single `<NameValueList>` with multiple `<Value>` children, matching eBay's expected format.

## Verification
- [x] Build passes (`pnpm build`)
- [x] No unrelated changes
- [x] All resolved issues have `Closes #XX`
- [x] Backward compatible — single string values still work unchanged

## Notes for Reviewer
- RC5 (value-matcher) and RC7 (UI multi-select widget) are deferred to Phase 2/3 per the issue's proposed fix strategy
- The normalizer's delimiter splitting acts as a defensive safety net for both legacy concatenated data and new array data from intake-station
- The enrichment blob parser accepts both old (`string`) and new (`string[]`) formats, so existing Odoo data continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)