### PR TITLE
[Fix] Preview: split specs into generic/device groups, truncate long text

### DIFF
--- a/packages/listing-processor/templates/preview.eta
+++ b/packages/listing-processor/templates/preview.eta
@@ -2,7 +2,7 @@
   title: `${it.product.x_brand || ''} ${it.product.x_model_name || ''} — Preview`.trim(),
   activeNav: it.activeNav,
   flashes: it.flashes,
-  head: '<style>.preview-grid{display:grid;grid-template-columns:1fr 1fr;gap:1.25rem}@media(max-width:960px){.preview-grid{grid-template-columns:1fr}}.img-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px}.img-grid img{width:100%;aspect-ratio:1;object-fit:cover;border-radius:4px;border:1px solid var(--border-muted);cursor:pointer}.img-grid img:hover{border-color:var(--blue)}.spec-table td:first-child{font-weight:600;white-space:nowrap;width:35%;color:var(--text-2)}.title-option{padding:8px 10px;border:1px solid var(--border-muted);border-radius:4px;cursor:pointer;margin-bottom:6px;display:flex;justify-content:space-between;align-items:center;transition:border-color .15s}.title-option:hover{border-color:var(--blue)}.title-option .chars{font-size:12px;color:var(--text-3);white-space:nowrap;margin-left:12px}.desc-preview{border:1px solid var(--border-muted);border-radius:4px;padding:12px;max-height:500px;overflow-y:auto;background:#fff}.desc-edit textarea{width:100%;min-height:300px;font-family:monospace;font-size:12px}.action-bar{display:flex;gap:8px;flex-wrap:wrap;padding:16px 0;border-top:1px solid var(--border-muted);margin-top:16px}.lightbox{display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);z-index:1000;cursor:pointer;align-items:center;justify-content:center}.lightbox.open{display:flex}.lightbox img{max-width:90vw;max-height:90vh;object-fit:contain}.cat-suggestion{padding:6px 10px;border:1px solid var(--border-muted);cursor:pointer;margin-bottom:4px;display:flex;justify-content:space-between;align-items:center;font-size:12px;transition:border-color .15s}.cat-suggestion:hover{border-color:var(--blue);background:var(--surface-alt)}.cat-suggestion.selected{border-color:var(--green);background:var(--green-subtle)}.cat-breadcrumb{color:var(--text-3);font-size:11px}.btn-loading{opacity:.7;cursor:wait;pointer-events:none}@keyframes pulse-bg{0%,100%{opacity:.7}50%{opacity:.4}}.btn-loading{animation:pulse-bg 1.2s ease-in-out infinite}.spec-row{display:grid;grid-template-columns:180px 1fr 28px;gap:6px;align-items:center;padding:4px 0;border-bottom:1px solid var(--border-muted)}.spec-row:last-child{border-bottom:none}.spec-row label{font-size:12px;color:var(--text-2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.spec-row label .req{color:var(--red);font-weight:700}.spec-row label .rec{color:var(--blue);font-size:10px;margin-left:2px}.spec-row input,.spec-row select{font-size:12px;padding:3px 6px;border:1px solid var(--border-muted);border-radius:3px;width:100%}.spec-row input:focus,.spec-row select:focus{border-color:var(--blue);outline:none}.spec-row .spec-status{font-size:14px;text-align:center}.spec-section-toggle{font-size:11px;color:var(--blue);cursor:pointer;border:none;background:none;padding:4px 0;text-decoration:underline}.specs-header-info{font-size:11px;color:var(--text-3)}.tag-container{display:flex;flex-wrap:wrap;gap:4px;align-items:center;min-height:28px;padding:2px 4px;border:1px solid var(--border-muted);border-radius:3px;background:#fff;cursor:text}.tag-container:focus-within{border-color:var(--blue)}.tag-chip{display:inline-flex;align-items:center;gap:2px;padding:1px 6px;background:var(--blue);color:#fff;border-radius:12px;font-size:11px;line-height:1.6;max-width:100%;white-space:nowrap}.tag-chip.over-limit{background:var(--red)}.tag-chip .tag-remove{cursor:pointer;font-size:13px;line-height:1;opacity:.8;margin-left:2px;font-weight:700}.tag-chip .tag-remove:hover{opacity:1}.tag-input{border:none;outline:none;font-size:12px;min-width:60px;flex:1;padding:2px 4px;background:transparent}.mv-checkboxes{display:flex;flex-wrap:wrap;gap:4px;max-height:150px;overflow-y:auto;padding:4px 0}.mv-checkboxes label{display:inline-flex;align-items:center;gap:3px;font-size:11px;padding:2px 6px;border:1px solid var(--border-muted);border-radius:3px;cursor:pointer;white-space:nowrap}.mv-checkboxes label:hover{border-color:var(--blue)}.mv-checkboxes label.checked{border-color:var(--blue);background:var(--blue);color:#fff}.mv-check-toggle{font-size:11px;color:var(--blue);cursor:pointer;border:none;background:none;padding:2px 0;text-decoration:underline}</style>'
+  head: '<style>.preview-grid{display:grid;grid-template-columns:1fr 1fr;gap:1.25rem}@media(max-width:960px){.preview-grid{grid-template-columns:1fr}}.img-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px}.img-grid img{width:100%;aspect-ratio:1;object-fit:cover;border-radius:4px;border:1px solid var(--border-muted);cursor:pointer}.img-grid img:hover{border-color:var(--blue)}.spec-table td:first-child{font-weight:600;white-space:nowrap;width:35%;color:var(--text-2)}.title-option{padding:8px 10px;border:1px solid var(--border-muted);border-radius:4px;cursor:pointer;margin-bottom:6px;display:flex;justify-content:space-between;align-items:center;transition:border-color .15s}.title-option:hover{border-color:var(--blue)}.title-option .chars{font-size:12px;color:var(--text-3);white-space:nowrap;margin-left:12px}.desc-preview{border:1px solid var(--border-muted);border-radius:4px;padding:12px;max-height:500px;overflow-y:auto;background:#fff}.desc-edit textarea{width:100%;min-height:300px;font-family:monospace;font-size:12px}.action-bar{display:flex;gap:8px;flex-wrap:wrap;padding:16px 0;border-top:1px solid var(--border-muted);margin-top:16px}.lightbox{display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);z-index:1000;cursor:pointer;align-items:center;justify-content:center}.lightbox.open{display:flex}.lightbox img{max-width:90vw;max-height:90vh;object-fit:contain}.cat-suggestion{padding:6px 10px;border:1px solid var(--border-muted);cursor:pointer;margin-bottom:4px;display:flex;justify-content:space-between;align-items:center;font-size:12px;transition:border-color .15s}.cat-suggestion:hover{border-color:var(--blue);background:var(--surface-alt)}.cat-suggestion.selected{border-color:var(--green);background:var(--green-subtle)}.cat-breadcrumb{color:var(--text-3);font-size:11px}.btn-loading{opacity:.7;cursor:wait;pointer-events:none}@keyframes pulse-bg{0%,100%{opacity:.7}50%{opacity:.4}}.btn-loading{animation:pulse-bg 1.2s ease-in-out infinite}.spec-row{display:grid;grid-template-columns:180px 1fr 28px;gap:6px;align-items:center;padding:4px 0;border-bottom:1px solid var(--border-muted)}.spec-row:last-child{border-bottom:none}.spec-row label{font-size:12px;color:var(--text-2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.spec-row label .req{color:var(--red);font-weight:700}.spec-row label .rec{color:var(--blue);font-size:10px;margin-left:2px}.spec-row input,.spec-row select{font-size:12px;padding:3px 6px;border:1px solid var(--border-muted);border-radius:3px;width:100%}.spec-row input:focus,.spec-row select:focus{border-color:var(--blue);outline:none}.spec-row .spec-status{font-size:14px;text-align:center}.spec-section-toggle{font-size:11px;color:var(--blue);cursor:pointer;border:none;background:none;padding:4px 0;text-decoration:underline}.specs-header-info{font-size:11px;color:var(--text-3)}.tag-container{display:flex;flex-wrap:wrap;gap:4px;align-items:center;min-height:28px;padding:2px 4px;border:1px solid var(--border-muted);border-radius:3px;background:#fff;cursor:text}.tag-container:focus-within{border-color:var(--blue)}.tag-chip{display:inline-flex;align-items:center;gap:2px;padding:1px 6px;background:var(--blue);color:#fff;border-radius:12px;font-size:11px;line-height:1.6;max-width:100%;white-space:nowrap}.tag-chip.over-limit{background:var(--red)}.tag-chip .tag-remove{cursor:pointer;font-size:13px;line-height:1;opacity:.8;margin-left:2px;font-weight:700}.tag-chip .tag-remove:hover{opacity:1}.tag-input{border:none;outline:none;font-size:12px;min-width:60px;flex:1;padding:2px 4px;background:transparent}.mv-checkboxes{display:flex;flex-wrap:wrap;gap:4px;max-height:150px;overflow-y:auto;padding:4px 0}.mv-checkboxes label{display:inline-flex;align-items:center;gap:3px;font-size:11px;padding:2px 6px;border:1px solid var(--border-muted);border-radius:3px;cursor:pointer;white-space:nowrap}.mv-checkboxes label:hover{border-color:var(--blue)}.mv-checkboxes label.checked{border-color:var(--blue);background:var(--blue);color:#fff}.mv-check-toggle{font-size:11px;color:var(--blue);cursor:pointer;border:none;background:none;padding:2px 0;text-decoration:underline}.truncatable{max-height:60px;overflow:hidden;position:relative}.truncatable.expanded{max-height:none}.truncatable-toggle{font-size:11px;color:var(--blue);cursor:pointer;border:none;background:none;padding:2px 0;text-decoration:underline;display:block;margin-top:2px}</style>'
 }) %>
 
 <%
@@ -46,24 +46,21 @@
             <div class="panel-header">Product Specs (Odoo #<%= p.id %>)</div>
             <table class="spec-table">
                 <%
-                const specRows = [
+                const genericRows = [
                     ['Brand', p.x_brand], ['Series', p.x_series], ['Model', p.x_model_name],
+                    ['Condition', ({ new: 'New', like_new: 'Like New', good: 'Good', fair: 'Fair', parts: 'For Parts' })[p.x_condition] || p.x_condition],
+                    ['Color', p.x_color],
+                ];
+                const deviceRows = [
                     ['Processor', p.x_processor], ['Speed', p.x_processor_speed],
                     ['RAM', p.x_ram_size], ['Storage', [p.x_storage_capacity, p.x_storage_type].filter(Boolean).join(' ')],
                     ['GPU', p.x_gpu], ['Graphics', p.x_graphics_type],
                     ['Screen', p.x_screen_size], ['Resolution', p.x_max_resolution],
                     ['OS', p.x_operating_system],
-                    ['Condition', ({ new: 'New', like_new: 'Like New', good: 'Good', fair: 'Fair', parts: 'For Parts' })[p.x_condition] || p.x_condition],
-                    ['Color', p.x_color], ['Connectivity', p.x_connectivity],
+                    ['Connectivity', p.x_connectivity],
                     ['Features', p.x_features],
                 ];
-                %>
-                <% for (const [label, val] of specRows) { %>
-                <% if (val && val !== false) { %>
-                <tr><td><%= label %></td><td><%= val %></td></tr>
-                <% } %>
-                <% } %>
-                <%
+                const hasDeviceSpecs = deviceRows.some(([_, v]) => v && v !== false);
                 const testFields = [
                     ['Display', p.x_test_display], ['Keyboard', p.x_test_keyboard],
                     ['Touchpad', p.x_test_touchpad], ['Speakers', p.x_test_speakers],
@@ -73,12 +70,34 @@
                 ];
                 const passedTests = testFields.filter(([_, v]) => v && v !== false);
                 %>
+                <% for (const [label, val] of genericRows) { %>
+                <% if (val && val !== false) { %>
+                <% if (String(val).length > 80) { %>
+                <tr><td><%= label %></td><td><div class="truncatable"><%= val %></div><button type="button" class="truncatable-toggle" onclick="this.previousElementSibling.classList.toggle('expanded');this.textContent=this.previousElementSibling.classList.contains('expanded')?'Show less':'Show more'">Show more</button></td></tr>
+                <% } else { %>
+                <tr><td><%= label %></td><td><%= val %></td></tr>
+                <% } %>
+                <% } %>
+                <% } %>
+                <% if (hasDeviceSpecs) { %>
+                <tr><td colspan="2" style="font-weight:700;padding-top:12px;color:var(--text-1);font-size:13px;">Device Specs</td></tr>
+                <% for (const [label, val] of deviceRows) { %>
+                <% if (val && val !== false) { %>
+                <% if (String(val).length > 80) { %>
+                <tr><td><%= label %></td><td><div class="truncatable"><%= val %></div><button type="button" class="truncatable-toggle" onclick="this.previousElementSibling.classList.toggle('expanded');this.textContent=this.previousElementSibling.classList.contains('expanded')?'Show less':'Show more'">Show more</button></td></tr>
+                <% } else { %>
+                <tr><td><%= label %></td><td><%= val %></td></tr>
+                <% } %>
+                <% } %>
+                <% } %>
+                <% } %>
                 <% if (passedTests.length > 0) { %>
+                <tr><td colspan="2" style="font-weight:700;padding-top:12px;color:var(--text-1);font-size:13px;">Test Results</td></tr>
                 <tr><td>Tests</td><td class="text-green"><%= passedTests.map(t => t[0]).join(', ') %></td></tr>
                 <% } %>
                 <% if (p.x_battery_health) { %><tr><td>Battery</td><td><%= p.x_battery_health %><% if (p.x_battery_cycles) { %> (<%= p.x_battery_cycles %> cycles)<% } %></td></tr><% } %>
-                <% if (p.x_cosmetic_notes) { %><tr><td>Cosmetic</td><td class="text-xs"><%= p.x_cosmetic_notes %></td></tr><% } %>
-                <% if (p.x_functional_notes) { %><tr><td>Functional</td><td class="text-xs"><%= p.x_functional_notes %></td></tr><% } %>
+                <% if (p.x_cosmetic_notes) { %><tr><td>Cosmetic</td><td class="text-xs"><div class="truncatable"><%= p.x_cosmetic_notes %></div><button type="button" class="truncatable-toggle" onclick="this.previousElementSibling.classList.toggle('expanded');this.textContent=this.previousElementSibling.classList.contains('expanded')?'Show less':'Show more'">Show more</button></td></tr><% } %>
+                <% if (p.x_functional_notes) { %><tr><td>Functional</td><td class="text-xs"><div class="truncatable"><%= p.x_functional_notes %></div><button type="button" class="truncatable-toggle" onclick="this.previousElementSibling.classList.toggle('expanded');this.textContent=this.previousElementSibling.classList.contains('expanded')?'Show less':'Show more'">Show more</button></td></tr><% } %>
                 <tr><td>Cost</td><td>$<%= p.standard_price ? p.standard_price.toFixed(2) : '0.00' %></td></tr>
                 <tr><td>List Price</td><td>$<%= p.list_price ? p.list_price.toFixed(2) : '0.00' %></td></tr>
             </table>


### PR DESCRIPTION
## Summary
- Splits Product Specs panel into generic fields (all products) and device-specific fields (laptops/computers), fixing irrelevant labels for non-laptop products
- Adds CSS truncation with Show more/less toggle for long free-text fields (connectivity, cosmetic notes, functional notes) that were overflowing the panel

## Issues Resolved
- Closes #59 — Product Specs panel uses hardcoded laptop-specific fields
- Closes #61 — Long text fields (notes, connectivity) overflow Product Specs panel

## Changes
- **File:** `packages/listing-processor/templates/preview.eta`
  - Split `specRows` into `genericRows` (Brand, Series, Model, Condition, Color) and `deviceRows` (Processor, RAM, Storage, GPU, etc.)
  - Device rows only render when at least one has a value, under a "Device Specs" sub-header
  - Test results grouped under a "Test Results" sub-header
  - Added `.truncatable` CSS class (max-height:60px, overflow:hidden) with expand toggle
  - Applied truncation to spec values >80 chars and to cosmetic/functional notes fields

## Verification
- [x] Build passes (`pnpm build`)
- [x] No unrelated changes
- [x] All resolved issues have `Closes #XX`
- [x] Single file changed: preview.eta (32 insertions, 13 deletions)

## Notes for Reviewer
This is Level 1 fix for both issues — minimal, surgical changes. The existing empty-field filtering already hides null fields, so laptop rows naturally won't appear for non-laptop products. The truncation threshold (60px / 80 chars) can be tuned if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)